### PR TITLE
fix default value of gloo.gatewayProxies.gatewayProxy.service.type for V1.7.1 and dev

### DIFF
--- a/dev/02.安装与配置/03.helm.md
+++ b/dev/02.安装与配置/03.helm.md
@@ -67,7 +67,7 @@ Zadig Chart 除了 Zadig 系统外，还内置了一些必要的组件 Ingress C
 
 | Key                                           | 说明                                                              | Value 示例   | 默认值   |
 |-----------------------------------------------|-------------------------------------------------------------------|--------------|----------|
-| gloo.gatewayProxies.gatewayProxy.service.type | Gateway Proxy 服务的暴露方式，可选项为 LoadBalancer 或者 NodePort | LoadBalancer | NodePort |
+| gloo.gatewayProxies.gatewayProxy.service.type | Gateway Proxy 服务的暴露方式，可选项为 LoadBalancer 或者 NodePort | LoadBalancer | LoadBalancer |
 
 ### Ingress Controller 可选参数
 

--- a/v1.7.1/02.安装与配置/03.helm.md
+++ b/v1.7.1/02.安装与配置/03.helm.md
@@ -67,7 +67,7 @@ Zadig Chart 除了 Zadig 系统外，还内置了一些必要的组件 Ingress C
 
 | Key                                           | 说明                                                              | Value 示例   | 默认值   |
 |-----------------------------------------------|-------------------------------------------------------------------|--------------|----------|
-| gloo.gatewayProxies.gatewayProxy.service.type | Gateway Proxy 服务的暴露方式，可选项为 LoadBalancer 或者 NodePort | LoadBalancer | NodePort |
+| gloo.gatewayProxies.gatewayProxy.service.type | Gateway Proxy 服务的暴露方式，可选项为 LoadBalancer 或者 NodePort | LoadBalancer | LoadBalancer |
 
 ### Ingress Controller 可选参数
 


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

Default value of gloo.gatewayProxies.gatewayProxy.service.type in `V1.7.1` and `dev` is wrong. Fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig-doc/208)
<!-- Reviewable:end -->
